### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/src/WebApp/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/src/WebApp/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1068,6 +1068,11 @@ $.extend( $.validator, {
 			return this.groups[ element.name ] || ( this.checkable( element ) ? element.name : element.id || element.name );
 		},
 
+		/**
+		 * Returns the validation target for the given element.
+		 * Only accepts DOM elements; strings and jQuery objects wrapping strings are rejected for security.
+		 * If a string or non-DOM object is passed, returns undefined and logs a warning.
+		 */
 		validationTargetFor: function( element ) {
 
 			// If radio/checkbox, validate first element in group instead
@@ -1075,7 +1080,7 @@ $.extend( $.validator, {
 				element = this.findByName( element.name );
 			}
 
-			// Only accept DOM elements or jQuery objects; reject strings to prevent XSS
+			// Only accept DOM elements; reject strings to prevent XSS
 			if (typeof element === "string") {
 				if (window.console) {
 					console.warn("Unsafe string passed to validationTargetFor; ignoring for security.");
@@ -1085,6 +1090,13 @@ $.extend( $.validator, {
 			// If it's a jQuery object, extract the first DOM element
 			if (element && element.jquery) {
 				element = element[0];
+			}
+			// Ensure it's a DOM element (nodeType === 1)
+			if (!element || typeof element !== "object" || element.nodeType !== 1) {
+				if (window.console) {
+					console.warn("Non-DOM element passed to validationTargetFor; ignoring for security.");
+				}
+				return undefined;
 			}
 			// Always apply ignore filter
 			return $(element).not(this.settings.ignore)[0];


### PR DESCRIPTION
Potential fix for [https://github.com/DwaineDGIlmer/EzLeadGenerator/security/code-scanning/5](https://github.com/DwaineDGIlmer/EzLeadGenerator/security/code-scanning/5)

To fix the problem, we need to ensure that the `validationTargetFor` method only passes actual DOM elements to the jQuery `$()` function, never strings or jQuery objects wrapping strings. This can be achieved by adding a stricter type check: if the input is a string, return `undefined`; if it's a jQuery object, extract the first element and ensure it's a DOM element; otherwise, check that the input is a DOM element before passing it to `$()`. Additionally, the plugin should document in its options that only DOM elements are accepted and that passing strings is unsafe and will be ignored. The changes should be made in the `validationTargetFor` method in `src/WebApp/wwwroot/lib/jquery-validation/dist/jquery.validate.js`, specifically around line 1090.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
