### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/master_ezleadgenerator.yml
+++ b/.github/workflows/master_ezleadgenerator.yml
@@ -38,6 +38,8 @@ jobs:
   deploy:
     runs-on: windows-latest
     needs: build
+    permissions:
+      contents: read
     environment:
       name: 'Production'
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}


### PR DESCRIPTION
Potential fix for [https://github.com/DwaineDGIlmer/EzLeadGenerator/security/code-scanning/2](https://github.com/DwaineDGIlmer/EzLeadGenerator/security/code-scanning/2)

To fix the problem, add a `permissions` block to the `deploy` job in `.github/workflows/master_ezleadgenerator.yml`. The minimal required permissions for this job should be set to `contents: read`, unless the job requires additional permissions (which, based on the provided steps, it does not). This change should be made directly under the `deploy:` job definition, at the same indentation level as `runs-on`, `needs`, and `environment`. No additional imports or definitions are needed; this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
