### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/DwaineDGIlmer/EzLeadGenerator/security/code-scanning/1](https://github.com/DwaineDGIlmer/EzLeadGenerator/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code and runs build/test commands, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the root level of the workflow (above `jobs:`), which will apply to all jobs unless overridden. This change should be made in `.github/workflows/dotnet.yml`, above the `jobs:` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
